### PR TITLE
Create files when opened for writing

### DIFF
--- a/core/src/main/scala/quasar/fs/inmemory.scala
+++ b/core/src/main/scala/quasar/fs/inmemory.scala
@@ -87,6 +87,7 @@ object inmemory {
           i <- nextSeq
           h =  WriteHandle(i)
           _ <- wFileL(h) := Some(f)
+          _ <- fileL(f) %= (_ orElse Some(Vector()))
         } yield h.right
 
       case WriteFile.Write(h, xs) =>

--- a/core/src/main/scala/quasar/physical/mongodb/fs/writefile.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/fs/writefile.scala
@@ -25,7 +25,8 @@ object writefile {
       case Open(file) =>
         Collection.fromFile(file) fold (
           err => PathError(err).left.point[MongoWrite],
-          col => recordCollection(col) map \/.right)
+          col => ensureCollection(col).liftM[WriteStateT] *>
+                 recordCollection(col) map \/.right)
 
       case Write(h, data) =>
         val (errs, docs) = data foldMap { d =>

--- a/core/src/test/scala/quasar/fs/ReadFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/ReadFileSpec.scala
@@ -16,11 +16,11 @@ class ReadFileSpec extends Specification with ScalaCheck with FileSystemFixture 
 
   "ReadFile" should {
     "scan should read data until an empty vector is received" ! prop {
-      (f: AbsFile[Sandboxed], xs: Vector[Data]) => xs.nonEmpty ==> {
-        val p = write.appendF(f, xs).drain ++ read.scanAll(f)
+      (f: AbsFile[Sandboxed], xs: Vector[Data]) =>
 
-        evalLogZero(p).run.toEither must beRight(xs)
-      }
+      val p = write.appendF(f, xs).drain ++ read.scanAll(f)
+
+      evalLogZero(p).run.toEither must beRight(xs)
     }
 
     "scan should automatically close the read handle when terminated early" ! prop {

--- a/core/src/test/scala/quasar/fs/WriteFileSpec.scala
+++ b/core/src/test/scala/quasar/fs/WriteFileSpec.scala
@@ -18,14 +18,14 @@ class WriteFileSpec extends Specification with ScalaCheck with FileSystemFixture
   "WriteFile" should {
 
     "append should consume input and close write handle when finished" ! prop {
-      (f: AbsFile[Sandboxed], xs: Vector[Data]) => xs.nonEmpty ==> {
-        val p = write.appendF(f, xs).drain ++ read.scanAll(f)
+      (f: AbsFile[Sandboxed], xs: Vector[Data]) =>
 
-        p.translate[M](runT).runLog.run
-          .leftMap(_.wm)
-          .run(emptyMem)
-          .run must_== ((Map.empty, \/.right(xs)))
-      }
+      val p = write.appendF(f, xs).drain ++ read.scanAll(f)
+
+      p.translate[M](runT).runLog.run
+        .leftMap(_.wm)
+        .run(emptyMem)
+        .run must_== ((Map.empty, \/.right(xs)))
     }
 
     "append should aggregate all `PartialWrite` errors and emit the sum" ! prop {
@@ -40,18 +40,18 @@ class WriteFileSpec extends Specification with ScalaCheck with FileSystemFixture
     }
 
     "save should replace existing file" ! prop {
-      (f: AbsFile[Sandboxed], xs: Vector[Data], ys: Vector[Data]) => (xs.nonEmpty && ys.nonEmpty) ==> {
-        val p = (write.appendF(f, xs) ++ write.saveF(f, ys)).drain ++ read.scanAll(f)
+      (f: AbsFile[Sandboxed], xs: Vector[Data], ys: Vector[Data]) =>
 
-        evalLogZero(p).run.toEither must beRight(ys)
-      }
+      val p = (write.appendF(f, xs) ++ write.saveF(f, ys)).drain ++ read.scanAll(f)
+
+      evalLogZero(p).run.toEither must beRight(ys)
     }
 
-    "save with empty input should not create the file" ! prop { f: AbsFile[Sandboxed] =>
+    "save with empty input should create an empty file" ! prop { f: AbsFile[Sandboxed] =>
       val p = write.saveF(f, Vector[Data]()) ++
               (manage.fileExists(f).liftM[FileSystemErrT]: manage.M[Boolean]).liftM[Process]
 
-      evalLogZero(p).run must_== \/.right(Vector(false))
+      evalLogZero(p).run must_== \/.right(Vector(true))
     }
 
     "save should leave existing file untouched on failure" ! prop {
@@ -68,25 +68,25 @@ class WriteFileSpec extends Specification with ScalaCheck with FileSystemFixture
     }
 
     "create should fail if file exists" ! prop {
-      (f: AbsFile[Sandboxed], xs: Vector[Data], ys: Vector[Data]) => (xs.nonEmpty && ys.nonEmpty) ==> {
-        val p = write.appendF(f, xs) ++ write.createF(f, ys)
+      (f: AbsFile[Sandboxed], xs: Vector[Data], ys: Vector[Data]) =>
 
-        evalLogZero(p).run.toEither must beLeft(PathError(FileExists(f)))
-      }
+      val p = write.appendF(f, xs) ++ write.createF(f, ys)
+
+      evalLogZero(p).run.toEither must beLeft(PathError(FileExists(f)))
     }
 
     "create should consume all input into a new file" ! prop {
-      (f: AbsFile[Sandboxed], xs: Vector[Data]) => xs.nonEmpty ==> {
-        evalLogZero(write.createF(f, xs) ++ read.scanAll(f))
-          .run.toEither must beRight(xs)
-      }
+      (f: AbsFile[Sandboxed], xs: Vector[Data]) =>
+
+      evalLogZero(write.createF(f, xs) ++ read.scanAll(f))
+        .run.toEither must beRight(xs)
     }
 
     "replace should fail if the file does not exist" ! prop {
-      (f: AbsFile[Sandboxed], xs: Vector[Data]) => xs.nonEmpty ==> {
-        evalLogZero(write.replaceF(f, xs))
-          .run.toEither must beLeft(PathError(FileNotFound(f)))
-      }
+      (f: AbsFile[Sandboxed], xs: Vector[Data]) =>
+
+      evalLogZero(write.replaceF(f, xs))
+        .run.toEither must beLeft(PathError(FileNotFound(f)))
     }
 
     "replace should leave the existing file untouched on failure" ! prop {
@@ -103,11 +103,11 @@ class WriteFileSpec extends Specification with ScalaCheck with FileSystemFixture
     }
 
     "replace should overwrite the existing file with new data" ! prop {
-      (f: AbsFile[Sandboxed], xs: Vector[Data], ys: Vector[Data]) => (xs.nonEmpty && ys.nonEmpty) ==> {
-        val p = write.saveF(f, xs) ++ write.replaceF(f, ys) ++ read.scanAll(f)
+      (f: AbsFile[Sandboxed], xs: Vector[Data], ys: Vector[Data]) =>
 
-        evalLogZero(p).run.toEither must beRight(ys)
-      }
+      val p = write.saveF(f, xs) ++ write.replaceF(f, ys) ++ read.scanAll(f)
+
+      evalLogZero(p).run.toEither must beRight(ys)
     }
   }
 }

--- a/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ManageFilesSpec.scala
@@ -227,7 +227,9 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
         val p = write.saveF(f, oneDoc).drain ++
                 (manage.tempFileNear(f).liftM[FileSystemErrT]: manage.M[AbsFile[Sandboxed]])
                   .liftM[Process] flatMap { tf =>
-                    write.saveF(tf, anotherDoc).drain ++ read.scanAll(tf)
+                    write.saveF(tf, anotherDoc).drain ++
+                    read.scanAll(tf) ++
+                    manage.deleteFile(tf).liftM[Process].drain
                   }
 
         runLogT(run, p).runEither must beRight(anotherDoc)
@@ -238,7 +240,9 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
         val f = d </> file("somefile")
         val p = (manage.tempFileNear(f).liftM[FileSystemErrT]: manage.M[AbsFile[Sandboxed]])
                   .liftM[Process] flatMap { tf =>
-                    write.saveF(tf, anotherDoc).drain ++ read.scanAll(tf)
+                    write.saveF(tf, anotherDoc).drain ++
+                    read.scanAll(tf) ++
+                    manage.deleteFile(tf).liftM[Process].drain
                   }
 
         runLogT(run, p).runEither must beRight(anotherDoc)
@@ -247,7 +251,9 @@ class ManageFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT)
       "write/read from arbitrary temp dir" >> {
         val p = (manage.anyTempFile.liftM[FileSystemErrT]: manage.M[AbsFile[Sandboxed]])
                   .liftM[Process] flatMap { tf =>
-                    write.saveF(tf, oneDoc).drain ++ read.scanAll(tf)
+                    write.saveF(tf, oneDoc).drain ++
+                    read.scanAll(tf) ++
+                    manage.deleteFile(tf).liftM[Process].drain
                   }
 
         runLogT(run, p).runEither must beRight(oneDoc)

--- a/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
+++ b/it/src/test/scala/quasar/fs/ReadFilesSpec.scala
@@ -70,6 +70,11 @@ class ReadFilesSpec extends FileSystemTest[FileSystem](FileSystemTest.allFsUT) {
         }
       }
 
+      "scan an empty file succeeds, yielding no data" >> {
+        val r = runLogT(run, read.scanAll(emptyFile.file))
+        r.runEither must beRight((xs: scala.collection.IndexedSeq[Data]) => xs must beEmpty)
+      }
+
       "scan with offset zero and no limit reads entire file" >> {
         val r = runLogT(run, read.scan(smallFile.file, Natural._0, None))
         r.runEither must beRight(smallFile.data.toIndexedSeq)


### PR DESCRIPTION
This changes the specified behavior of `WriteFile` to eagerly create files, if they don't exist, when evaluating `Open` rather than on the first `Write`.
