### PR TITLE
Switch to XML for reading/writing files in MarkLogic

### DIFF
--- a/frontend/src/main/scala/quasar/data.scala
+++ b/frontend/src/main/scala/quasar/data.scala
@@ -98,6 +98,9 @@ object Data {
   val _obj =
     Prism.partial[Data, ListMap[String, Data]] { case Data.Obj(m) => m } (Data.Obj(_))
 
+  def singletonObj(k: String, v: Data): Data =
+    Obj(ListMap(k -> v))
+
   final case class Arr(value: List[Data]) extends Data {
     def dataType = Type.Arr(value ∘ (Type.Const(_)))
     def toJs = value.traverse(_.toJs).map(jscore.Arr(_))

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/ops.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/ops.scala
@@ -21,7 +21,7 @@ import quasar.Data
 import quasar.contrib.pathy._
 import quasar.fp.free.lift
 import quasar.fs._
-import quasar.physical.marklogic.fs.data.toXml
+import quasar.physical.marklogic.fs.data.encodeXml
 import quasar.physical.marklogic.uuid._
 import quasar.physical.marklogic.xcc._
 import quasar.physical.marklogic.xml._
@@ -74,7 +74,7 @@ object ops {
 
     val xmlData: Vector[FileSystemError \/ String] =
       data map { d =>
-        toXml[ErrorMessages \/ ?](d).bimap(
+        encodeXml[ErrorMessages \/ ?](d).bimap(
           ms => FileSystemError.writeFailed(d, ms.intercalate(", ")),
           _.toString)
       }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/package.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/package.scala
@@ -17,6 +17,7 @@
 package quasar.physical.marklogic
 
 import quasar.Predef._
+import quasar.Data
 import quasar.effect.{KeyValueStore, MonotonicSeq}
 import quasar.fp._
 import quasar.fp.free._
@@ -108,7 +109,7 @@ package object fs {
         rc.close.void
 
       def nextChunk(rc: ResultCursor) =
-        TV.map(rc.nextChunk)(xdmitem.toData)
+        TV.map(rc.nextChunk)(xdm => xdmitem.toData[ErrorMessages \/ ?](xdm) | Data.NA)
 
       val TV = Functor[Task].compose[Vector]
     }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/xdmitem.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/xdmitem.scala
@@ -33,24 +33,24 @@ object xdmitem {
   def toData[F[_]: MonadErrMsgs](xdm: XdmItem): F[Data] = xdm match {
     case item: CtsBox                   =>
       Data.singletonObj("cts:box", Data.Obj(ListMap(
-        "east"  -> Data.Str(item.getEast),
-        "north" -> Data.Str(item.getNorth),
-        "south" -> Data.Str(item.getSouth),
-        "west"  -> Data.Str(item.getWest)
+        "east"  -> Data._str(item.getEast),
+        "north" -> Data._str(item.getNorth),
+        "south" -> Data._str(item.getSouth),
+        "west"  -> Data._str(item.getWest)
       ))).point[F]
 
     case item: CtsCircle                =>
       toData[F](item.getCenter) map { center =>
         Data.singletonObj("cts:circle", Data.Obj(ListMap(
            "center" -> center,
-           "radius" -> Data.Str(item.getRadius)
+           "radius" -> Data._str(item.getRadius)
          )))
       }
 
     case item: CtsPoint                 =>
       Data.singletonObj("cts:point", Data.Obj(ListMap(
-        "latitude"  -> Data.Str(item.getLatitude),
-        "longitude" -> Data.Str(item.getLongitude)
+        "latitude"  -> Data._str(item.getLatitude),
+        "longitude" -> Data._str(item.getLongitude)
       ))).point[F]
 
     case item: CtsPolygon               =>
@@ -65,35 +65,35 @@ object xdmitem {
 
     case item: XdmAttribute             =>
       val attr = item.asW3cAttr
-      Data.singletonObj(attr.getName, Data.Str(attr.getValue)).point[F]
+      Data.singletonObj(attr.getName, Data._str(attr.getValue)).point[F]
 
     // TODO: Inefficient for large data as it must be buffered into memory
     case item: XdmBinary                => bytesToData[F](item.asBinaryData)
-    case item: XdmComment               => Data.singletonObj("xdm:comment"  , Data.Str(item.asString)).point[F]
+    case item: XdmComment               => Data.singletonObj("xdm:comment"  , Data._str(item.asString)).point[F]
     case item: XdmDocument              => xmlToData[F](item.asString)
     case item: XdmElement               => xmlToData[F](item.asString)
-    case item: XdmProcessingInstruction => Data.singletonObj("xdm:processingInstruction", Data.Str(item.asString)).point[F]
+    case item: XdmProcessingInstruction => Data.singletonObj("xdm:processingInstruction", Data._str(item.asString)).point[F]
     case item: XdmText                  => Data._str(item.asString).point[F]
     case item: XSAnyURI                 => Data._str(item.asString).point[F]
     case item: XSBase64Binary           => bytesToData[F](item.asBinaryData)
     case item: XSBoolean                => Data._bool(item.asPrimitiveBoolean).point[F]
-    case item: XSDate                   => Data.singletonObj("xs:date"      , Data.Str(item.asString)).point[F]
+    case item: XSDate                   => Data.singletonObj("xs:date"      , Data._str(item.asString)).point[F]
     case item: XSDateTime               => Data._timestamp(Instant.ofEpochMilli(item.asDate.getTime)).point[F]
     case item: XSDecimal                => Data._dec(item.asBigDecimal).point[F]
     case item: XSDouble                 => Data._dec(item.asBigDecimal).point[F]
-    case item: XSDuration               => Data.singletonObj("xs:duration"  , Data.Str(item.asString)).point[F]
+    case item: XSDuration               => Data.singletonObj("xs:duration"  , Data._str(item.asString)).point[F]
     case item: XSFloat                  => Data._dec(item.asBigDecimal).point[F]
-    case item: XSGDay                   => Data.singletonObj("xs:gDay"      , Data.Str(item.asString)).point[F]
-    case item: XSGMonth                 => Data.singletonObj("xs:gMonth"    , Data.Str(item.asString)).point[F]
-    case item: XSGMonthDay              => Data.singletonObj("xs:gMonthDay" , Data.Str(item.asString)).point[F]
-    case item: XSGYear                  => Data.singletonObj("xs:gYear"     , Data.Str(item.asString)).point[F]
-    case item: XSGYearMonth             => Data.singletonObj("xs:gYearMonth", Data.Str(item.asString)).point[F]
+    case item: XSGDay                   => Data.singletonObj("xs:gDay"      , Data._str(item.asString)).point[F]
+    case item: XSGMonth                 => Data.singletonObj("xs:gMonth"    , Data._str(item.asString)).point[F]
+    case item: XSGMonthDay              => Data.singletonObj("xs:gMonthDay" , Data._str(item.asString)).point[F]
+    case item: XSGYear                  => Data.singletonObj("xs:gYear"     , Data._str(item.asString)).point[F]
+    case item: XSGYearMonth             => Data.singletonObj("xs:gYearMonth", Data._str(item.asString)).point[F]
     case item: XSHexBinary              => bytesToData[F](item.asBinaryData)
     case item: XSInteger                => Data._int(item.asBigInteger).point[F]
     case item: XSQName                  => Data._str(item.asString).point[F]
     case item: XSString                 => Data._str(item.asString).point[F]
                                            // NB: This can be represented with org.threeten.bp.OffsetTime
-    case item: XSTime                   => Data.singletonObj("xs:time"      , Data.Str(item.asString)).point[F]
+    case item: XSTime                   => Data.singletonObj("xs:time"      , Data._str(item.asString)).point[F]
     case item: XSUntypedAtomic          => Data._str(item.asString).point[F]
     case other                          => s"No Data representation for '$other'.".wrapNel.raiseError[F, Data]
   }
@@ -114,7 +114,7 @@ object xdmitem {
 
     el flatMap { e =>
       if (xml.qualifiedName(e) === xml.namespaces.ejsonEjson.shows)
-        data.fromXml[F](e)
+        data.decodeXml[F](e)
       else
         xml.toData(e).point[F]
     }

--- a/marklogic/src/main/scala/quasar/physical/marklogic/fs/xdmitem.scala
+++ b/marklogic/src/main/scala/quasar/physical/marklogic/fs/xdmitem.scala
@@ -21,52 +21,102 @@ import quasar.Data
 import quasar.physical.marklogic.xml
 import quasar.physical.marklogic.xml.SecureXML
 
+import scala.collection.JavaConverters._
+import scala.util.{Success, Failure}
+import scala.xml.Elem
+
 import com.marklogic.xcc.types._
-import scalaz._
+import org.threeten.bp._
+import scalaz._, Scalaz._
 
 object xdmitem {
-  // TODO: What sort of error handling to we want?
-  val toData: XdmItem => Data = {
-    case item: CtsBox                   => ???
-    case item: CtsCircle                => ???
-    case item: CtsPoint                 => ???
-    case item: CtsPolygon               => ???
-    // TODO: What is the difference between JSArray/Object and their *Node variants?
-    case item: JSArray                  => ???
-    case item: JSObject                 => ???
-    case item: JsonItem                 => data.JsonParser.parseFromString(item.asString).getOrElse(Data.NA)
+  def toData[F[_]: MonadErrMsgs](xdm: XdmItem): F[Data] = xdm match {
+    case item: CtsBox                   =>
+      Data.singletonObj("cts:box", Data.Obj(ListMap(
+        "east"  -> Data.Str(item.getEast),
+        "north" -> Data.Str(item.getNorth),
+        "south" -> Data.Str(item.getSouth),
+        "west"  -> Data.Str(item.getWest)
+      ))).point[F]
+
+    case item: CtsCircle                =>
+      toData[F](item.getCenter) map { center =>
+        Data.singletonObj("cts:circle", Data.Obj(ListMap(
+           "center" -> center,
+           "radius" -> Data.Str(item.getRadius)
+         )))
+      }
+
+    case item: CtsPoint                 =>
+      Data.singletonObj("cts:point", Data.Obj(ListMap(
+        "latitude"  -> Data.Str(item.getLatitude),
+        "longitude" -> Data.Str(item.getLongitude)
+      ))).point[F]
+
+    case item: CtsPolygon               =>
+      item.getVertices.asScala.toList traverse toData[F] map { verts =>
+        Data.singletonObj("cts:polygon", Data.singletonObj("vertices", Data.Arr(verts)))
+      }
+
+    // TODO: What is the difference between JS{Array, Object} and their *Node variants?
+    case item: JSArray                  => jsonToData[F](item.asString)
+    case item: JSObject                 => jsonToData[F](item.asString)
+    case item: JsonItem                 => jsonToData[F](item.asString)
 
     case item: XdmAttribute             =>
       val attr = item.asW3cAttr
-      Data.Obj(ListMap(attr.getName -> Data.Str(attr.getValue)))
+      Data.singletonObj(attr.getName, Data.Str(attr.getValue)).point[F]
 
     // TODO: Inefficient for large data as it must be buffered into memory
-    case item: XdmBinary                => Data.Binary(ImmutableArray.fromArray(item.asBinaryData))
-    case item: XdmComment               => Data.NA
-    case item: XdmDocument              => SecureXML.loadString(item.asString) map (xml.toData) getOrElse Data.NA
-    case item: XdmElement               => SecureXML.loadString(item.asString) map (xml.toData) getOrElse Data.NA
-    case item: XdmProcessingInstruction => Data.NA
-    case item: XdmText                  => Data.Str(item.asString)
-    case item: XSAnyURI                 => Data.Str(item.asString)
-    case item: XSBase64Binary           => Data.Binary(ImmutableArray.fromArray(item.asBinaryData))
-    case item: XSBoolean                => Data.Bool(item.asPrimitiveBoolean)
-    case item: XSDate                   => ???
-    case item: XSDateTime               => ???
-    case item: XSDecimal                => Data.Dec(item.asBigDecimal)
-    case item: XSDouble                 => Data.Dec(item.asBigDecimal)
-    case item: XSDuration               => ???
-    case item: XSFloat                  => Data.Dec(item.asBigDecimal)
-    case item: XSGDay                   => ???
-    case item: XSGMonth                 => ???
-    case item: XSGMonthDay              => ???
-    case item: XSGYear                  => ???
-    case item: XSGYearMonth             => ???
-    case item: XSHexBinary              => Data.Binary(ImmutableArray.fromArray(item.asBinaryData))
-    case item: XSInteger                => Data.Int(item.asBigInteger)
-    case item: XSQName                  => Data.Str(item.asString)
-    case item: XSString                 => Data.Str(item.asString)
-    case item: XSTime                   => ???
-    case item: XSUntypedAtomic          => ???
-    case _                              => Data.NA // This case should not be hit although we can't prove it.
+    case item: XdmBinary                => bytesToData[F](item.asBinaryData)
+    case item: XdmComment               => Data.singletonObj("xdm:comment"  , Data.Str(item.asString)).point[F]
+    case item: XdmDocument              => xmlToData[F](item.asString)
+    case item: XdmElement               => xmlToData[F](item.asString)
+    case item: XdmProcessingInstruction => Data.singletonObj("xdm:processingInstruction", Data.Str(item.asString)).point[F]
+    case item: XdmText                  => Data._str(item.asString).point[F]
+    case item: XSAnyURI                 => Data._str(item.asString).point[F]
+    case item: XSBase64Binary           => bytesToData[F](item.asBinaryData)
+    case item: XSBoolean                => Data._bool(item.asPrimitiveBoolean).point[F]
+    case item: XSDate                   => Data.singletonObj("xs:date"      , Data.Str(item.asString)).point[F]
+    case item: XSDateTime               => Data._timestamp(Instant.ofEpochMilli(item.asDate.getTime)).point[F]
+    case item: XSDecimal                => Data._dec(item.asBigDecimal).point[F]
+    case item: XSDouble                 => Data._dec(item.asBigDecimal).point[F]
+    case item: XSDuration               => Data.singletonObj("xs:duration"  , Data.Str(item.asString)).point[F]
+    case item: XSFloat                  => Data._dec(item.asBigDecimal).point[F]
+    case item: XSGDay                   => Data.singletonObj("xs:gDay"      , Data.Str(item.asString)).point[F]
+    case item: XSGMonth                 => Data.singletonObj("xs:gMonth"    , Data.Str(item.asString)).point[F]
+    case item: XSGMonthDay              => Data.singletonObj("xs:gMonthDay" , Data.Str(item.asString)).point[F]
+    case item: XSGYear                  => Data.singletonObj("xs:gYear"     , Data.Str(item.asString)).point[F]
+    case item: XSGYearMonth             => Data.singletonObj("xs:gYearMonth", Data.Str(item.asString)).point[F]
+    case item: XSHexBinary              => bytesToData[F](item.asBinaryData)
+    case item: XSInteger                => Data._int(item.asBigInteger).point[F]
+    case item: XSQName                  => Data._str(item.asString).point[F]
+    case item: XSString                 => Data._str(item.asString).point[F]
+                                           // NB: This can be represented with org.threeten.bp.OffsetTime
+    case item: XSTime                   => Data.singletonObj("xs:time"      , Data.Str(item.asString)).point[F]
+    case item: XSUntypedAtomic          => Data._str(item.asString).point[F]
+    case other                          => s"No Data representation for '$other'.".wrapNel.raiseError[F, Data]
+  }
+
+  ////
+
+  private def bytesToData[F[_]: Applicative](bytes: Array[Byte]): F[Data] =
+    Data._binary(ImmutableArray.fromArray(bytes)).point[F]
+
+  private def jsonToData[F[_]: MonadErrMsgs](jsonString: String): F[Data] =
+    data.JsonParser.parseFromString(jsonString) match {
+      case Success(d) => d.point[F]
+      case Failure(e) => e.toString.wrapNel.raiseError[F, Data]
+    }
+
+  private def xmlToData[F[_]: MonadErrMsgs](xmlString: String): F[Data] = {
+    val el = SecureXML.loadString(xmlString).fold(_.toString.wrapNel.raiseError[F, Elem], _.point[F])
+
+    el flatMap { e =>
+      if (xml.qualifiedName(e) === xml.namespaces.ejsonEjson.shows)
+        data.fromXml[F](e)
+      else
+        xml.toData(e).point[F]
+    }
   }
 }

--- a/marklogic/src/test/scala/quasar/physical/marklogic/fs/DataXmlEncodingSpec.scala
+++ b/marklogic/src/test/scala/quasar/physical/marklogic/fs/DataXmlEncodingSpec.scala
@@ -16,7 +16,7 @@
 
 package quasar.physical.marklogic.fs
 
-import quasar.physical.marklogic.fs.data.{toXml, fromXml}
+import quasar.physical.marklogic.fs.data.{encodeXml, decodeXml}
 import quasar.physical.marklogic.xml.SecureXML
 
 import scalaz._, Scalaz._
@@ -26,15 +26,15 @@ final class DataXmlEncodingSpec extends quasar.Qspec {
 
   "Data <-> XML encoding" should {
     "roundtrip" >> prop { xd: XmlSafeData =>
-      toXml[Result](xd.data).flatMap(fromXml[Result]) must_= xd.data.right
+      encodeXml[Result](xd.data).flatMap(decodeXml[Result]) must_= xd.data.right
     }
 
     "roundtrip through serialization" >> prop { xd: XmlSafeData =>
       val rt = for {
-        xml <- toXml[Result](xd.data)
+        xml <- encodeXml[Result](xd.data)
         el  <- SecureXML.loadString(xml.toString)
                  .leftMap(e => e.toString.wrapNel)
-        d   <- fromXml[Result](el)
+        d   <- decodeXml[Result](el)
       } yield d
 
       rt must_= xd.data.right


### PR DESCRIPTION
- Finish the XdmItem -> Data conversion
- Better error handling, delaying the crush to Data.NA as far as possible

@jedesah This finishes the `FileSystem` side of the XML conversion, all the filesystem specs are passing.
