### PR TITLE
removed CPath arg from Wrap parse instruction

### DIFF
--- a/frontend/src/main/scala/quasar/ParseInstruction.scala
+++ b/frontend/src/main/scala/quasar/ParseInstruction.scala
@@ -35,10 +35,10 @@ sealed trait FocusedParseInstruction extends ParseInstruction
 object ParseInstruction {
 
   /**
-   * Wraps the provided `path` into an object with key `name`, thus adding
-   * another layer of structure. All other paths are retained.
+   * Wraps the row into an object with key `name`, thus adding
+   * another layer of structure.
    */
-  final case class Wrap(path: CPath, name: String) extends FocusedParseInstruction
+  final case class Wrap(name: String) extends FocusedParseInstruction
 
   /**
    *`Masks` represents the disjunction of the provided `masks`. An empty map indicates
@@ -77,7 +77,7 @@ object ParseInstruction {
 
   implicit val focusedParseInstructionEqual: Equal[FocusedParseInstruction] =
     Equal.equal {
-      case (Wrap(p1, n1), Wrap(p2, n2)) => p1 === p2 && n1 === n2
+      case (Wrap(n1), Wrap(n2)) => n1 === n2
       case (Mask(m1), Mask(m2)) => m1 === m2
       case (Pivot(s1, t1), Pivot(s2, t2)) => s1 === s2 && t1 === t2
       case (Project(p1), Project(p2)) => p1 === p2
@@ -94,7 +94,7 @@ object ParseInstruction {
 
   implicit val focusedParseInstructionShow: Show[FocusedParseInstruction] =
     Show.show {
-      case Wrap(p, n) => Cord("Wrap(") ++ p.show ++ Cord(", ") ++ n.show ++ Cord(")")
+      case Wrap(n) => Cord("Wrap(") ++ n.show ++ Cord(")")
       case Mask(m) => Cord("Mask(") ++ m.show ++ Cord(")")
       case Pivot(s, t) => Cord("Pivot(") ++ s.show ++ Cord(", ") ++ t.show  ++ Cord(")")
       case Project(p) => Cord("Project(") ++ p.show ++ Cord(")")

--- a/frontend/src/main/scala/quasar/ParseInstruction.scala
+++ b/frontend/src/main/scala/quasar/ParseInstruction.scala
@@ -57,7 +57,7 @@ object ParseInstruction {
    *
    * No values outside of the pivot locus should be retained.
    */
-  final case class Pivot(path: CPath, status: IdStatus, structure: CompositeParseType)
+  final case class Pivot(status: IdStatus, structure: CompositeParseType)
       extends FocusedParseInstruction
 
   /**
@@ -79,7 +79,7 @@ object ParseInstruction {
     Equal.equal {
       case (Wrap(p1, n1), Wrap(p2, n2)) => p1 === p2 && n1 === n2
       case (Mask(m1), Mask(m2)) => m1 === m2
-      case (Pivot(p1, s1, t1), Pivot(p2, s2, t2)) => p1 === p2 && s1 === s2 && t1 === t2
+      case (Pivot(s1, t1), Pivot(s2, t2)) => s1 === s2 && t1 === t2
       case (Project(p1), Project(p2)) => p1 === p2
       case (_, _) => false
     }
@@ -96,8 +96,7 @@ object ParseInstruction {
     Show.show {
       case Wrap(p, n) => Cord("Wrap(") ++ p.show ++ Cord(", ") ++ n.show ++ Cord(")")
       case Mask(m) => Cord("Mask(") ++ m.show ++ Cord(")")
-      case Pivot(p, s, t) =>
-        Cord("Pivot(") ++ p.show ++ Cord(", ") ++ s.show ++ Cord(", ") ++ t.show  ++ Cord(")")
+      case Pivot(s, t) => Cord("Pivot(") ++ s.show ++ Cord(", ") ++ t.show  ++ Cord(")")
       case Project(p) => Cord("Project(") ++ p.show ++ Cord(")")
     }
 

--- a/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
+++ b/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
@@ -149,7 +149,7 @@ object ParseInstructionSpec {
     protected final val Wrap = ParseInstruction.Wrap
 
     "wrap" should {
-      "nest scalars at identity" in {
+      "nest scalars" in {
         val input = ldjson("""
           1
           "hi"
@@ -162,10 +162,10 @@ object ParseInstructionSpec {
           { "foo": true }
           """)
 
-        input must wrapInto(".", "foo")(expected)
+        input must wrapInto("foo")(expected)
       }
 
-      "nest vectors at identity" in {
+      "nest vectors" in {
         val input = ldjson("""
           [1, 2, 3]
           { "a": "hi", "b": { "c": null } }
@@ -178,154 +178,17 @@ object ParseInstructionSpec {
           { "bar": [{ "d": {} }] }
           """)
 
-        input must wrapInto(".", "bar")(expected)
-      }
-
-      "nest scalars at .a.b" in {
-        val input = ldjson("""
-          { "a": { "b": 1 } }
-          { "a": { "b": "hi" } }
-          { "a": { "b": true } }
-          """)
-
-        val expected = ldjson("""
-          { "a": { "b": { "foo": 1 } } }
-          { "a": { "b": { "foo": "hi" } } }
-          { "a": { "b": { "foo": true } } }
-          """)
-
-        input must wrapInto(".a.b", "foo")(expected)
-      }
-
-      "nest scalars at .a.b keeping rows excluding the target" in {
-        val input = ldjson("""
-          { "a": { "b": 1 } }
-          { "a": { "c": 2 } }
-          { "a": { "b": "hi" } }
-          { "a": { "d": "bye" } }
-          {}
-          []
-          42
-          """)
-
-        val expected = ldjson("""
-          { "a": { "b": { "foo": 1 } } }
-          { "a": { "c": 2 } }
-          { "a": { "b": { "foo": "hi" } } }
-          { "a": { "d": "bye" } }
-          {}
-          []
-          42
-          """)
-
-        input must wrapInto(".a.b", "foo")(expected)
-      }
-
-      "nest scalars at .a[1] with surrounding structure" in {
-        val input = ldjson("""
-          { "a": [null, 1, "nada"] }
-          { "a": [[], "hi"] }
-          { "a": [null, true, "nada"] }
-          """)
-
-        val expected = ldjson("""
-          { "a": [null, { "bin": 1 }, "nada"] }
-          { "a": [[], { "bin": "hi" }] }
-          { "a": [null, { "bin": true }, "nada"] }
-          """)
-
-        input must wrapInto(".a[1]", "bin")(expected)
-      }
-
-      "nest scalars at .a[2] with surrounding structure keeping rows excluding the target" in {
-        val input = ldjson("""
-          { "a": [null, 1, "nada"] }
-          { "a": [[], "hi"] }
-          { "a": [null, true, "nada", "nix", "nil"] }
-          { "a": [] }
-          {}
-          []
-          42
-          """)
-
-        val expected = ldjson("""
-          { "a": [null, 1, { "bin": "nada" }] }
-          { "a": [[], "hi"] }
-          { "a": [null, true, { "bin": "nada" }, "nix", "nil"] }
-          { "a": [] }
-          {}
-          []
-          42
-          """)
-
-        input must wrapInto(".a[2]", "bin")(expected)
-      }
-
-      "nest vectors at .a.b" in {
-        val input = ldjson("""
-          { "a": { "b": [1, 2, 3] } }
-          { "a": { "b": { "a": "hi", "b": { "c": null } } } }
-          { "a": { "b": [{ "d": {} }] } }
-          """)
-
-        val expected = ldjson("""
-          { "a": { "b": { "bar": [1, 2, 3] } } }
-          { "a": { "b": { "bar": { "a": "hi", "b": { "c": null } } } } }
-          { "a": { "b": { "bar": [{ "d": {} }] } } }
-          """)
-
-        input must wrapInto(".a.b", "bar")(expected)
-      }
-
-      "retain surrounding structure with scalars at .a.b" in {
-        val input = ldjson("""
-          { "z": null, "a": { "b": 1 }, "d": false, "b": [] }
-          { "z": [], "a": { "b": "hi" }, "d": "to be or not to be", "b": { "a": 321} }
-          { "z": { "a": { "b": 3.14 } }, "a": { "b": true }, "d": {} }
-          """)
-
-        val expected = ldjson("""
-          { "z": null, "a": { "b": { "qux": 1 } }, "d": false, "b": [] }
-          { "z": [], "a": { "b": { "qux": "hi" } }, "d": "to be or not to be", "b": { "a": 321} }
-          { "z": { "a": { "b": 3.14 } }, "a": { "b": { "qux": true } }, "d": {} }
-          """)
-
-        input must wrapInto(".a.b", "qux")(expected)
-      }
-
-      "retain surrounding structure with scalars at .a.b keeping rows excluding the target" in {
-        val input = ldjson("""
-          { "z": null, "a": { "b": 1 }, "d": false, "b": [] }
-          { "z": [], "a": { "b": "hi" }, "d": "to be or not to be", "b": { "a": 321} }
-          { "z": { "a": { "b": 3.14 } }, "a": { "c": null }, "d": {} }
-          { "z": { "a": { "b": 3.14 } }, "a": { "b": true }, "d": {} }
-          {}
-          []
-          42
-          """)
-
-        val expected = ldjson("""
-          { "z": null, "a": { "b": { "qux": 1 } }, "d": false, "b": [] }
-          { "z": [], "a": { "b": { "qux": "hi" } }, "d": "to be or not to be", "b": { "a": 321} }
-          { "z": { "a": { "b": 3.14 } }, "a": { "c": null }, "d": {} }
-          { "z": { "a": { "b": 3.14 } }, "a": { "b": { "qux": true } }, "d": {} }
-          {}
-          []
-          42
-          """)
-
-        input must wrapInto(".a.b", "qux")(expected)
+        input must wrapInto("bar")(expected)
       }
     }
 
     def evalWrap(wrap: Wrap, stream: JsonStream): JsonStream
 
     def wrapInto(
-        path: String,
         name: String)(
         expected: JsonStream)
         : Matcher[JsonStream] =
-      bestSemanticEqual(expected) ^^ { str: JsonStream => evalWrap(Wrap(CPath.parse(path), name), str)}
+      bestSemanticEqual(expected) ^^ { str: JsonStream => evalWrap(Wrap(name), str)}
   }
 
   trait ProjectSpec extends JsonSpec {

--- a/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
+++ b/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
@@ -880,7 +880,7 @@ object ParseInstructionSpec {
     protected final val Pivot = ParseInstruction.Pivot
 
     "pivot" should {
-      "shift an array at identity" >> {
+      "shift an array" >> {
         val input = ldjson("""
           [1, 2, 3]
           [4, 5, 6]
@@ -907,7 +907,7 @@ object ParseInstructionSpec {
             13
             """)
 
-          input must pivotInto(".", IdStatus.ExcludeId, ParseType.Array)(expected)
+          input must pivotInto(IdStatus.ExcludeId, ParseType.Array)(expected)
         }
 
         "IdOnly" >> {
@@ -927,7 +927,7 @@ object ParseInstructionSpec {
             1
             """)
 
-          input must pivotInto(".", IdStatus.IdOnly, ParseType.Array)(expected)
+          input must pivotInto(IdStatus.IdOnly, ParseType.Array)(expected)
         }
 
         "IncludeId" >> {
@@ -947,154 +947,11 @@ object ParseInstructionSpec {
             [1, 13]
             """)
 
-          input must pivotInto(".", IdStatus.IncludeId, ParseType.Array)(expected)
+          input must pivotInto(IdStatus.IncludeId, ParseType.Array)(expected)
         }
       }
 
-      "shift an array at .a.b (with no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": { "b": [1, 2, 3] } }
-          { "a": { "b": [4, 5, 6] } }
-          { "a": { "b": [7, 8, 9, 10] } }
-          { "a": { "b": [11] } }
-          { "a": { "b": [] } }
-          { "a": { "b": [12, 13] } }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 3 } }
-            { "a": { "b": 4 } }
-            { "a": { "b": 5 } }
-            { "a": { "b": 6 } }
-            { "a": { "b": 7 } }
-            { "a": { "b": 8 } }
-            { "a": { "b": 9 } }
-            { "a": { "b": 10 } }
-            { "a": { "b": 11 } }
-            { "a": { "b": 12 } }
-            { "a": { "b": 13 } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.ExcludeId, ParseType.Array)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 3 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IdOnly, ParseType.Array)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": [0, 1] } }
-            { "a": { "b": [1, 2] } }
-            { "a": { "b": [2, 3] } }
-            { "a": { "b": [0, 4] } }
-            { "a": { "b": [1, 5] } }
-            { "a": { "b": [2, 6] } }
-            { "a": { "b": [0, 7] } }
-            { "a": { "b": [1, 8] } }
-            { "a": { "b": [2, 9] } }
-            { "a": { "b": [3, 10] } }
-            { "a": { "b": [0, 11] } }
-            { "a": { "b": [0, 12] } }
-            { "a": { "b": [1, 13] } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IncludeId, ParseType.Array)(expected)
-        }
-      }
-
-     "shift an array at .a[0] (with no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": [ [1, 2, 3] ] }
-          { "a": [ [4, 5, 6] ] }
-          { "a": [ [7, 8, 9, 10] ] }
-          { "a": [ [11] ] }
-          { "a": [ [] ] }
-          { "a": [ [12, 13] ] }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 3 ] }
-            { "a": [ 4 ] }
-            { "a": [ 5 ] }
-            { "a": [ 6 ] }
-            { "a": [ 7 ] }
-            { "a": [ 8 ] }
-            { "a": [ 9 ] }
-            { "a": [ 10 ] }
-            { "a": [ 11 ] }
-            { "a": [ 12 ] }
-            { "a": [ 13 ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.ExcludeId, ParseType.Array)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 3 ] }
-            { "a": [ 0 ] }
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IdOnly, ParseType.Array)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": [ [0, 1] ] }
-            { "a": [ [1, 2] ] }
-            { "a": [ [2, 3] ] }
-            { "a": [ [0, 4] ] }
-            { "a": [ [1, 5] ] }
-            { "a": [ [2, 6] ] }
-            { "a": [ [0, 7] ] }
-            { "a": [ [1, 8] ] }
-            { "a": [ [2, 9] ] }
-            { "a": [ [3, 10] ] }
-            { "a": [ [0, 11] ] }
-            { "a": [ [0, 12] ] }
-            { "a": [ [1, 13] ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IncludeId, ParseType.Array)(expected)
-        }
-      }
-
-
-      "shift an object at identity" >> {
+      "shift an object" >> {
         val input = ldjson("""
           { "a": 1, "b": 2, "c": 3 }
           { "d": 4, "e": 5, "f": 6 }
@@ -1121,7 +978,7 @@ object ParseInstructionSpec {
             13
             """)
 
-          input must pivotInto(".", IdStatus.ExcludeId, ParseType.Object)(expected)
+          input must pivotInto(IdStatus.ExcludeId, ParseType.Object)(expected)
         }
 
         "IdOnly" >> {
@@ -1141,7 +998,7 @@ object ParseInstructionSpec {
             "m"
             """)
 
-          input must pivotInto(".", IdStatus.IdOnly, ParseType.Object)(expected)
+          input must pivotInto(IdStatus.IdOnly, ParseType.Object)(expected)
         }
 
         "IncludeId" >> {
@@ -1161,162 +1018,8 @@ object ParseInstructionSpec {
             ["m", 13]
             """)
 
-          input must pivotInto(".", IdStatus.IncludeId, ParseType.Object)(expected)
+          input must pivotInto(IdStatus.IncludeId, ParseType.Object)(expected)
         }
-      }
-
-      "shift an object at .a.b (no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": { "b": { "a": 1, "b": 2, "c": 3 } } }
-          { "a": { "b": { "d": 4, "e": 5, "f": 6 } } }
-          { "a": { "b": { "g": 7, "h": 8, "i": 9, "j": 10 } } }
-          { "a": { "b": { "k": 11 } } }
-          { "a": { "b": {} } }
-          { "a": { "b": { "l": 12, "m": 13 } } }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 3 } }
-            { "a": { "b": 4 } }
-            { "a": { "b": 5 } }
-            { "a": { "b": 6 } }
-            { "a": { "b": 7 } }
-            { "a": { "b": 8 } }
-            { "a": { "b": 9 } }
-            { "a": { "b": 10 } }
-            { "a": { "b": 11 } }
-            { "a": { "b": 12 } }
-            { "a": { "b": 13 } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.ExcludeId, ParseType.Object)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": { "b": "a" } }
-            { "a": { "b": "b" } }
-            { "a": { "b": "c" } }
-            { "a": { "b": "d" } }
-            { "a": { "b": "e" } }
-            { "a": { "b": "f" } }
-            { "a": { "b": "g" } }
-            { "a": { "b": "h" } }
-            { "a": { "b": "i" } }
-            { "a": { "b": "j" } }
-            { "a": { "b": "k" } }
-            { "a": { "b": "l" } }
-            { "a": { "b": "m" } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IdOnly, ParseType.Object)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": ["a", 1] } }
-            { "a": { "b": ["b", 2] } }
-            { "a": { "b": ["c", 3] } }
-            { "a": { "b": ["d", 4] } }
-            { "a": { "b": ["e", 5] } }
-            { "a": { "b": ["f", 6] } }
-            { "a": { "b": ["g", 7] } }
-            { "a": { "b": ["h", 8] } }
-            { "a": { "b": ["i", 9] } }
-            { "a": { "b": ["j", 10] } }
-            { "a": { "b": ["k", 11] } }
-            { "a": { "b": ["l", 12] } }
-            { "a": { "b": ["m", 13] } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IncludeId, ParseType.Object)(expected)
-        }
-      }
-
-      "shift an object at .a[0] (no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": [ { "a": 1, "b": 2, "c": 3 } ] }
-          { "a": [ { "d": 4, "e": 5, "f": 6 } ] }
-          { "a": [ { "g": 7, "h": 8, "i": 9, "j": 10 } ] }
-          { "a": [ { "k": 11 } ] }
-          { "a": [ {} ] }
-          { "a": [ { "l": 12, "m": 13 } ] }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 3 ] }
-            { "a": [ 4 ] }
-            { "a": [ 5 ] }
-            { "a": [ 6 ] }
-            { "a": [ 7 ] }
-            { "a": [ 8 ] }
-            { "a": [ 9 ] }
-            { "a": [ 10 ] }
-            { "a": [ 11 ] }
-            { "a": [ 12 ] }
-            { "a": [ 13 ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.ExcludeId, ParseType.Object)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": [ "a" ] }
-            { "a": [ "b" ] }
-            { "a": [ "c" ] }
-            { "a": [ "d" ] }
-            { "a": [ "e" ] }
-            { "a": [ "f" ] }
-            { "a": [ "g" ] }
-            { "a": [ "h" ] }
-            { "a": [ "i" ] }
-            { "a": [ "j" ] }
-            { "a": [ "k" ] }
-            { "a": [ "l" ] }
-            { "a": [ "m" ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IdOnly, ParseType.Object)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": [ ["a", 1] ] }
-            { "a": [ ["b", 2] ] }
-            { "a": [ ["c", 3] ] }
-            { "a": [ ["d", 4] ] }
-            { "a": [ ["e", 5] ] }
-            { "a": [ ["f", 6] ] }
-            { "a": [ ["g", 7] ] }
-            { "a": [ ["h", 8] ] }
-            { "a": [ ["i", 9] ] }
-            { "a": [ ["j", 10] ] }
-            { "a": [ ["k", 11] ] }
-            { "a": [ ["l", 12] ] }
-            { "a": [ ["m", 13] ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IncludeId, ParseType.Object)(expected)
-        }
-      }
-
-      "shift an object under .shifted with IncludeId and only one field" in {
-        val input = ldjson("""
-          { "shifted": { "shifted1": { "foo": "bar" } } }
-          """)
-
-        val expected = ldjson("""
-          { "shifted": ["shifted1", { "foo": "bar" }] }
-          """)
-
-        input must pivotInto(".shifted", IdStatus.IncludeId, ParseType.Object)(expected)
       }
 
       "preserve empty arrays as values of an array pivot" in {
@@ -1336,7 +1039,7 @@ object ParseInstructionSpec {
           "four"
         """)
 
-        input must pivotInto(".", IdStatus.ExcludeId, ParseType.Array)(expected)
+        input must pivotInto(IdStatus.ExcludeId, ParseType.Array)(expected)
       }
 
       "preserve empty objects as values of an object pivot" in {
@@ -1356,20 +1059,19 @@ object ParseInstructionSpec {
           "four"
         """)
 
-        input must pivotInto(".", IdStatus.ExcludeId, ParseType.Object)(expected)
+        input must pivotInto(IdStatus.ExcludeId, ParseType.Object)(expected)
       }
     }
 
     def evalPivot(pivot: Pivot, stream: JsonStream): JsonStream
 
     def pivotInto(
-        path: String,
         idStatus: IdStatus,
         structure: CompositeParseType)(
         expected: JsonStream)
         : Matcher[JsonStream] =
       bestSemanticEqual(expected) ^^ { str: JsonStream =>
-        evalPivot(Pivot(CPath.parse(path), idStatus, structure), str)
+        evalPivot(Pivot(idStatus, structure), str)
       }
   }
 
@@ -1452,11 +1154,11 @@ object ParseInstructionSpec {
 
         val targets = Map(
           (CPathField("a1"),
-            (CPathField("a0"), List(Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array)))),
+            (CPathField("a0"), List(Pivot(IdStatus.ExcludeId, ParseType.Array)))),
           (CPathField("b1"),
             (CPathField("b0"), Nil)),
           (CPathField("c1"),
-            (CPathField("c0"), List(Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Object)))))
+            (CPathField("c0"), List(Pivot(IdStatus.ExcludeId, ParseType.Object)))))
 
         input must cartesianInto(targets)(expected)
       }
@@ -1491,18 +1193,18 @@ object ParseInstructionSpec {
         val targets = Map(
           (CPathField("y"),
             (CPathField("a"), List(
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array),
+              Pivot(IdStatus.ExcludeId, ParseType.Array),
               Project(CPath.parse("x0")),
               Project(CPath.parse("y0")),
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Object)))),
+              Pivot(IdStatus.ExcludeId, ParseType.Object)))),
           (CPathField("z"),
             (CPathField("a"), List(
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array),
+              Pivot(IdStatus.ExcludeId, ParseType.Array),
               Project(CPath.parse("x1")),
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array)))),
+              Pivot(IdStatus.ExcludeId, ParseType.Array)))),
           (CPathField("b"),
             (CPathField("b"), List(
-              Pivot(CPath.Identity, IdStatus.IdOnly, ParseType.Object)))),
+              Pivot(IdStatus.IdOnly, ParseType.Object)))),
           (CPathField("c"),
             (CPathField("c"), Nil)))
 
@@ -1531,11 +1233,11 @@ object ParseInstructionSpec {
 
           (CPathField("ba"), (CPathField("b"), List(
             Mask(Map(CPath.Identity -> Set(ParseType.Array))),
-            Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array)))),
+            Pivot(IdStatus.ExcludeId, ParseType.Array)))),
 
           (CPathField("bm"), (CPathField("b"), List(
             Mask(Map(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Object)))))
+            Pivot(IdStatus.ExcludeId, ParseType.Object)))))
 
         input must cartesianInto(targets)(expected)
       }

--- a/impl/src/test/scala/quasar/impl/evaluate/RValueCartesianSpec.scala
+++ b/impl/src/test/scala/quasar/impl/evaluate/RValueCartesianSpec.scala
@@ -44,7 +44,7 @@ object RValueCartesianSpec extends JsonSpec {
 
   "RValue Cartesian interpreter" should {
 
-    val pivot = Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array)
+    val pivot = Pivot(IdStatus.ExcludeId, ParseType.Array)
 
     val cartouches = Map(
       (CPathField("a_"), (CPathField("a"), List(pivot))),

--- a/qscript/src/main/scala/quasar/qscript/rewrites/FocusedPushdown.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/FocusedPushdown.scala
@@ -62,7 +62,7 @@ final class FocusedPushdown[T[_[_]]: BirecursiveT: EqualT] private () extends TT
           FocusedRepair(repair)) =>
 
         val pivotInstr =
-          Pivot(CPath.Identity, shiftStatus, ShiftType.toParseType(shiftType))
+          Pivot(shiftStatus, ShiftType.toParseType(shiftType))
 
         val iread =
           IR[T[F]](Const(InterpretedRead(a, readStatus, instrs :+ pivotInstr)))

--- a/qscript/src/main/scala/quasar/qscript/rewrites/FocusedPushdown.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/FocusedPushdown.scala
@@ -260,7 +260,7 @@ final class FocusedPushdown[T[_[_]]: BirecursiveT: EqualT] private () extends TT
     _ match {
       case Map(Embed(Res(a, readStatus, instrs)), WrappedRec(p)) =>
         val wrappedInstrs =
-          p.foldRight(instrs)((s, ins) => ins :+ Wrap(CPath.Identity, s))
+          p.foldRight(instrs)((s, ins) => ins :+ Wrap(s))
 
         IR[T[F]](Const(InterpretedRead(a, readStatus, wrappedInstrs)))
 

--- a/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
@@ -121,7 +121,7 @@ object FocusedPushdownSpec extends Qspec {
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
               Pivot(IdOnly, ParseType.Object),
-              Wrap(CPath.Identity, "k1")))
+              Wrap("k1")))
 
         focusedPushdown(initial) must equal(expected)
       }
@@ -143,7 +143,7 @@ object FocusedPushdownSpec extends Qspec {
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
               Pivot(ExcludeId, ParseType.Object),
-              Wrap(CPath.Identity, "v1")))
+              Wrap("v1")))
 
         focusedPushdown(initial) must equal(expected)
       }
@@ -169,7 +169,7 @@ object FocusedPushdownSpec extends Qspec {
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
               Pivot(ExcludeId, ParseType.Object),
-              Wrap(CPath.Identity, "v1"))),
+              Wrap("v1"))),
           recFuncE.Constant(ejs.bool(true)))
 
       focusedPushdown(initial) must equal(expected)
@@ -434,7 +434,7 @@ object FocusedPushdownSpec extends Qspec {
             Project(CPath.parse(".[1].ddd")),
             Mask(SMap(CPath.Identity -> Set(ParseType.Array))),
             Pivot(ExcludeId, ParseType.Array),
-            Wrap(CPath.Identity, "result")))
+            Wrap("result")))
 
       focusedPushdown(initial) must_= expected
     }

--- a/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
@@ -95,7 +95,7 @@ object FocusedPushdownSpec extends Qspec {
               ExcludeId,
               List(
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -120,7 +120,7 @@ object FocusedPushdownSpec extends Qspec {
             ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-              Pivot(CPath.Identity, IdOnly, ParseType.Object),
+              Pivot(IdOnly, ParseType.Object),
               Wrap(CPath.Identity, "k1")))
 
         focusedPushdown(initial) must equal(expected)
@@ -142,7 +142,7 @@ object FocusedPushdownSpec extends Qspec {
             ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-              Pivot(CPath.Identity, ExcludeId, ParseType.Object),
+              Pivot(ExcludeId, ParseType.Object),
               Wrap(CPath.Identity, "v1")))
 
         focusedPushdown(initial) must equal(expected)
@@ -168,7 +168,7 @@ object FocusedPushdownSpec extends Qspec {
             ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-              Pivot(CPath.Identity, ExcludeId, ParseType.Object),
+              Pivot(ExcludeId, ParseType.Object),
               Wrap(CPath.Identity, "v1"))),
           recFuncE.Constant(ejs.bool(true)))
 
@@ -195,7 +195,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.Identity \ "xyz"),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -229,7 +229,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.parse(".aaa.bbb.ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -264,7 +264,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.parse(".aaa[42].ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -298,7 +298,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.parse(".[17][42].ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -323,7 +323,7 @@ object FocusedPushdownSpec extends Qspec {
           IncludeId,
           List(
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IncludeId, ParseType.Object)))
+            Pivot(IncludeId, ParseType.Object)))
 
       focusedPushdown(initial) must_= expected
     }
@@ -344,7 +344,7 @@ object FocusedPushdownSpec extends Qspec {
           IdOnly,
           List(
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IncludeId, ParseType.Object)))
+            Pivot(IncludeId, ParseType.Object)))
 
       focusedPushdown(initial) must_= expected
     }
@@ -430,10 +430,10 @@ object FocusedPushdownSpec extends Qspec {
           List(
             Project(CPath.parse(".aaa.bbb.ccc")),
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IncludeId, ParseType.Object),
+            Pivot(IncludeId, ParseType.Object),
             Project(CPath.parse(".[1].ddd")),
             Mask(SMap(CPath.Identity -> Set(ParseType.Array))),
-            Pivot(CPath.Identity, ExcludeId, ParseType.Array),
+            Pivot(ExcludeId, ParseType.Array),
             Wrap(CPath.Identity, "result")))
 
       focusedPushdown(initial) must_= expected


### PR DESCRIPTION
Seems that `Wrap` doesn't need `CPath` too, at least there is no tests that use other 